### PR TITLE
Make shaders compatible with OpenGL 4.1

### DIFF
--- a/assets/shader/border_line.fsh
+++ b/assets/shader/border_line.fsh
@@ -1,4 +1,4 @@
-#version 430
+#version 410
 
 uniform vec3 color;
 

--- a/assets/shader/border_line.vsh
+++ b/assets/shader/border_line.vsh
@@ -1,4 +1,4 @@
-#version 430
+#version 410
 
 uniform float aspect_ratio;
 uniform vec2 offset;

--- a/assets/shader/epicenter.fsh
+++ b/assets/shader/epicenter.fsh
@@ -1,11 +1,11 @@
-#version 430
+#version 410
 
 uniform sampler2D texture_sampler;
 
-layout (location = 0) in vec2 uv;
+layout (location = 0) in vec2 uv_gsh_out;
 
 out vec4 fragment_color;
 
 void main() {
-    fragment_color = texture(texture_sampler, uv);
+    fragment_color = texture(texture_sampler, uv_gsh_out);
 }

--- a/assets/shader/epicenter.gsh
+++ b/assets/shader/epicenter.gsh
@@ -1,4 +1,4 @@
-#version 430
+#version 410
 
 uniform float aspect_ratio;
 uniform float icon_ratio_in_y_axis;
@@ -6,7 +6,7 @@ uniform float icon_ratio_in_y_axis;
 layout(points) in;
 
 layout(triangle_strip, max_vertices = 4) out;
-layout (location = 0) out vec2 uv_out;
+layout (location = 0) out vec2 uv_gsh_out;
 
 void main() {
     vec4 position = gl_in[0].gl_Position.xyzw;
@@ -17,7 +17,7 @@ void main() {
         position.z,
         position[3]
     );
-    uv_out = vec2(0.0f, 0.0f);
+    uv_gsh_out = vec2(0.0f, 0.0f);
     EmitVertex();
 
     gl_Position = vec4(
@@ -26,7 +26,7 @@ void main() {
         position.z,
         position[3]
     );
-    uv_out = vec2(1.0f, 0.0f);
+    uv_gsh_out = vec2(1.0f, 0.0f);
     EmitVertex();
 
     gl_Position = vec4(
@@ -35,7 +35,7 @@ void main() {
         position.z,
         position[3]
     );
-    uv_out = vec2(0.0f, 1.0f);
+    uv_gsh_out = vec2(0.0f, 1.0f);
     EmitVertex();
 
     gl_Position = vec4(
@@ -44,7 +44,7 @@ void main() {
         position.z,
         position[3]
     );
-    uv_out = vec2(1.0f, 1.0f);
+    uv_gsh_out = vec2(1.0f, 1.0f);
     EmitVertex();
 
     EndPrimitive();

--- a/assets/shader/epicenter.vsh
+++ b/assets/shader/epicenter.vsh
@@ -1,4 +1,4 @@
-#version 430
+#version 410
 
 uniform float aspect_ratio;
 uniform vec2 offset;

--- a/assets/shader/intensity_icon.fsh
+++ b/assets/shader/intensity_icon.fsh
@@ -1,11 +1,11 @@
-#version 430
+#version 410
 
 uniform sampler2D texture_sampler;
 
-layout (location = 0) in vec2 uv;
+layout (location = 0) in vec2 uv_gsh_out;
 
 out vec4 fragment_color;
 
 void main() {
-    fragment_color = texture(texture_sampler, uv);
+    fragment_color = texture(texture_sampler, uv_gsh_out);
 }

--- a/assets/shader/intensity_icon.gsh
+++ b/assets/shader/intensity_icon.gsh
@@ -1,13 +1,13 @@
-#version 430
+#version 410
 
 uniform float aspect_ratio;
 uniform float icon_ratio_in_y_axis;
 
 layout(points) in;
-layout (location = 0) in vec2 uv_offset[];
+layout (location = 0) in vec2 uv_offset_vsh_out[];
 
 layout(triangle_strip, max_vertices = 4) out;
-layout (location = 0) out vec2 uv_out;
+layout (location = 0) out vec2 uv_gsh_out;
 
 void main() {
     vec4 position = gl_in[0].gl_Position.xyzw;
@@ -18,9 +18,9 @@ void main() {
             position.z,
             position[3]
     );
-    uv_out = vec2(
-            1.0f / 64.0f * 1.0 + uv_offset[0].x,
-            1.0f / 64.0f * 43.0f + uv_offset[0].y
+    uv_gsh_out = vec2(
+            1.0f / 64.0f * 1.0 + uv_offset_vsh_out[0].x,
+            1.0f / 64.0f * 43.0f + uv_offset_vsh_out[0].y
     );
     EmitVertex();
 
@@ -30,9 +30,9 @@ void main() {
         position.z,
         position[3]
     );
-    uv_out = vec2(
-        1.0f / 64.0f * 21.0 + uv_offset[0].x,
-        1.0f / 64.0f * 43.0f + uv_offset[0].y
+    uv_gsh_out = vec2(
+        1.0f / 64.0f * 21.0 + uv_offset_vsh_out[0].x,
+        1.0f / 64.0f * 43.0f + uv_offset_vsh_out[0].y
     );
     EmitVertex();
 
@@ -42,9 +42,9 @@ void main() {
         position.z,
         position[3]
     );
-    uv_out = vec2(
-        1.0f / 64.0f * 1.0 + uv_offset[0].x,
-        1.0f / 64.0f * 63.0f + uv_offset[0].y
+    uv_gsh_out = vec2(
+        1.0f / 64.0f * 1.0 + uv_offset_vsh_out[0].x,
+        1.0f / 64.0f * 63.0f + uv_offset_vsh_out[0].y
     );
     EmitVertex();
 
@@ -54,9 +54,9 @@ void main() {
         position.z,
         position[3]
     );
-    uv_out = vec2(
-        1.0f / 64.0f * 21.0 + uv_offset[0].x,
-        1.0f / 64.0f * 63.0f + uv_offset[0].y
+    uv_gsh_out = vec2(
+        1.0f / 64.0f * 21.0 + uv_offset_vsh_out[0].x,
+        1.0f / 64.0f * 63.0f + uv_offset_vsh_out[0].y
     );
     EmitVertex();
 

--- a/assets/shader/intensity_icon.vsh
+++ b/assets/shader/intensity_icon.vsh
@@ -1,4 +1,4 @@
-#version 430
+#version 410
 
 uniform float aspect_ratio;
 uniform vec2 offset;
@@ -7,7 +7,7 @@ uniform float zoom;
 in vec2 position;
 in vec2 uv_offset;
 
-layout (location = 0) out vec2 uv_offset_out;
+layout (location = 0) out vec2 uv_offset_vsh_out;
 
 const float EPSION = 1.19209290e-07;
 const float PI = 3.14159265358979323846264338327950288;
@@ -25,5 +25,5 @@ void main() {
     vec2 display_coordinate = vec2(map_coordinate.x, map_coordinate.y / aspect_ratio);
 
     gl_Position = vec4(display_coordinate, EPSION * gl_VertexID, 1.0);
-    uv_offset_out = uv_offset;
+    uv_offset_vsh_out = uv_offset;
 }

--- a/assets/shader/map.fsh
+++ b/assets/shader/map.fsh
@@ -1,4 +1,4 @@
-#version 430
+#version 410
 
 uniform vec3 color;
 

--- a/assets/shader/map.vsh
+++ b/assets/shader/map.vsh
@@ -1,4 +1,4 @@
-#version 430
+#version 410
 
 uniform float aspect_ratio;
 uniform vec2 offset;

--- a/assets/shader/textured.fsh
+++ b/assets/shader/textured.fsh
@@ -1,11 +1,11 @@
-#version 430
+#version 410
 
 uniform sampler2D texture_sampler;
 
-layout (location = 0) in vec2 uv;
+layout (location = 0) in vec2 uv_vsh_out;
 
 out vec4 fragment_color;
 
 void main() {
-    fragment_color = texture(texture_sampler, uv);
+    fragment_color = texture(texture_sampler, uv_vsh_out);
 }

--- a/assets/shader/textured.vsh
+++ b/assets/shader/textured.vsh
@@ -1,11 +1,11 @@
-#version 430
+#version 410
 
 in vec2 position;
 in vec2 uv;
 
-layout (location = 0) out vec2 uv_out;
+layout (location = 0) out vec2 uv_vsh_out;
 
 void main() {
     gl_Position = vec4(position, 0.0, 1.0);
-    uv_out = uv;
+    uv_vsh_out = uv;
 }


### PR DESCRIPTION
macOSはOpenGL 4.1以上をサポートしないようです
そのため現在のコード(4.3)のシェーダーは動作せずエラーになります
https://support.apple.com/ja-jp/101525

OpenGL 4.1において各シェーダーのin, outの名前が一致している必要があるようなので(裏取りなし)、名前を変更し動作するようにしました

このPRはシェーダーの修正のみを目的としています

Tested with: 
- macOS Version 15.1 Beta (24B5077a)
- Apple M3

<img width="832" alt="Screenshot 2024-10-17 at 20 11 19" src="https://github.com/user-attachments/assets/46594bd5-1f11-49df-b7ff-c3c2df054200">
