### PR TITLE
fix subtract with overflow

### DIFF
--- a/renderer/src/worker/fonts.rs
+++ b/renderer/src/worker/fonts.rs
@@ -167,8 +167,9 @@ impl FontManager<'_> {
             .collect();
         let indices: Vec<_> = (0..vertices.len() as u32 / 4)
             .map(|v| v * 4)
-            .scan(false, |&mut first_time, v| {
-                if first_time {
+            .scan(true, |first_time, v| {
+                if *first_time {
+                    *first_time = false;
                     Some(vec![v, v + 1, v + 2, v + 3])
                 } else {
                     Some(vec![v - 1, v, v, v + 1, v + 2, v + 3])


### PR DESCRIPTION


```
thread 'main' panicked at renderer/src/worker/fonts.rs:174:31:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```