### PR TITLE
Bump earcutr 0.4.3 -> 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 name = "asset-preprocessor"
 version = "0.1.0"
 dependencies = [
- "earcutr",
+ "earcutr 0.5.0",
  "geo",
  "itertools 0.14.0",
  "ordered-float",
@@ -781,6 +781,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "earcutr"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc28d89ac6cb489f679fcf51aaa62b4667bb0fb73a30f1d4d23949069707c07"
+dependencies = [
+ "itertools 0.14.0",
+ "num-traits",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,7 +1022,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4416397671d8997e9a3e7ad99714f4f00a22e9eaa9b966a5985d2194fc9e02e1"
 dependencies = [
- "earcutr",
+ "earcutr 0.4.3",
  "float_next_after",
  "geo-types",
  "geographiclib-rs",

--- a/asset-preprocessor/Cargo.toml
+++ b/asset-preprocessor/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-earcutr = "0.4.3"
+earcutr = "0.5.0"
 geo = "0.30"
 itertools = "0.14"
 ordered-float = "5.0"


### PR DESCRIPTION
なんかこいつが下手だったので
まぁgeoのdepが0.4.3に張り付いてるからコケてたんやろな～

https://github.com/EEWBot/eew-renderer/pull/60